### PR TITLE
Use esm instead of amd, see riot/riot#1715.

### DIFF
--- a/systemjs-riot.js
+++ b/systemjs-riot.js
@@ -4,13 +4,13 @@
 import compiler from 'riot-compiler';
 
 export function translate(load) {
-    var options = {
-        //expr: true
-        //type: 'babel'
-    };
-    load.metadata.format = 'esm';
-    var precompiled = compiler.compile(load.source, options);
-    var output = `import riot from 'riot';\n${precompiled}`;
+    let precompiled = compiler.compile(load.source);
+    let output;
+
+    if (load.metadata.format === 'esm')
+      output = `import riot from 'riot';\n${precompiled}`;
+    else
+      output = `define(['riot'], function(riot) { ${precompiled} });`;
 
     load.source = output;
     return output;

--- a/systemjs-riot.js
+++ b/systemjs-riot.js
@@ -7,10 +7,11 @@ export function translate(load) {
     let precompiled = compiler.compile(load.source);
     let output;
 
-    if (load.metadata.format === 'esm')
+    if (load.metadata.format === 'esm') {
       output = `import riot from 'riot';\n${precompiled}`;
-    else
+    } else {
       output = `define(['riot'], function(riot) { ${precompiled} });`;
+    }
 
     load.source = output;
     return output;

--- a/systemjs-riot.js
+++ b/systemjs-riot.js
@@ -8,9 +8,9 @@ export function translate(load) {
         //expr: true
         //type: 'babel'
     };
-    load.metadata.format = 'amd';
+    load.metadata.format = 'esm';
     var precompiled = compiler.compile(load.source, options);
-    var output = `define(['riot'], function(riot) { ${precompiled} });`;
+    var output = `import riot from 'riot';\n${precompiled}`;
 
     load.source = output;
     return output;


### PR DESCRIPTION
This allows for the following within a `.tag` file:

``` html
import baz from './baz'
<tag>
   <script>
     this.foo = baz('bar');
   </script>
</tag>
```
